### PR TITLE
Add GSM to GNN Inference Accelerators

### DIFF
--- a/res/papers/10-inference-accelerator.json
+++ b/res/papers/10-inference-accelerator.json
@@ -2,6 +2,13 @@
     "title": "GNN Inference Accelerators",
     "paper": [
         {
+            "venue": "IEEE Big Data 2025",
+            "name": "Degree-Based Scheduling and Memory Management for Large-Scale Exact Online GNN Inference",
+            "affiliation": "UVA & UIUC",
+            "link": "https://ieeexplore.ieee.org/abstract/document/11402115",
+            "source": "https://github.com/Alireza-3/GSM-Degree-based-scheduling-for-GNN-Inference-Serving"
+        },
+        {
             "venue": "JAIHC 2022",
             "name": "DRGN: a dynamically reconfigurable accelerator for graph neural networks",
             "affiliation": "XJTU",


### PR DESCRIPTION
## Summary

Adds GSM to the GNN Inference Accelerators paper list.

## Entry

- Venue: IEEE Big Data 2025
- Paper: Degree-Based Scheduling and Memory Management for Large-Scale Exact Online GNN Inference
- Affiliation: UVA & UIUC
- Paper link: https://ieeexplore.ieee.org/abstract/document/11402115
- Code link: https://github.com/Alireza-3/GSM-Degree-based-scheduling-for-GNN-Inference-Serving

## Validation

- `python3 -m json.tool res/papers/10-inference-accelerator.json`
- `git diff --check`
- Verified the generated README includes the GSM entry by running `src/rebuild_citation.py` and `src/update_readme.py` in a temporary copy.
